### PR TITLE
smaller H4 tag

### DIFF
--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -101,6 +101,9 @@ html h2 {
 html h3 {
   font-size: 1.5em;
 }
+html h4 {
+  font-size: 1.25em;
+}
 html p {
   margin: 0 0 0.8em;
 }


### PR DESCRIPTION
Both H3 & H4 have the same size & style on the live docs site.  This is confusing, since some sections have multiple H4 right after an H3.
Shrinking the H4 improve readability of the docs.

Thanks for all your work!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/hugo-docs/9)
<!-- Reviewable:end -->
