### PR TITLE
Make latency info optional

### DIFF
--- a/static/js/runnable.js
+++ b/static/js/runnable.js
@@ -293,7 +293,7 @@ function eraseCookie(name) {
       // In some cases, the server does not return latency information
       // TODO: find better ways to check for errors or fix dgraph to make the
       // response consistent
-      if (!res.code || !/Error/i.test(res.code)) {
+      if ((!res.code || !/Error/i.test(res.code)) && serverLatencyInfo) {
         updateLatencyInformation($runnables, serverLatencyInfo, networkLatency);
       }
 


### PR DESCRIPTION
For some queries, dgraph does not return `server_latency` even though debug param is set in the URL. For now, make latency info optional.

Related: https://github.com/dgraph-io/dgraph/issues/894

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/hugo-docs/11)
<!-- Reviewable:end -->
