### PR TITLE
Dynamically set dgraph endpoint

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -39,6 +39,13 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.25.0/mode/javascript/javascript.min.js" integrity="sha256-7Bdg/UdDMmHDPafpQDYZNPCEbnRP7eAvu+2hEoqRCXs=" crossorigin="anonymous"></script>
     <!-- END: Required by runnable -->
 
+    <script>
+      {{ $currentBranch := getenv "CURRENT_BRANCH" }}
+
+      {{/* Set dgraph endpoint depending on version to ensure that runnables work fine */}}
+      window.DGRAPH_ENDPOINT = {{ if eq $currentBranch "master" }}"https://play-master.dgraph.io/query?latency=true"{{ else }}"https://play.dgraph.io/query?latency=true"{{ end }}
+    </script>
+
     <title>
       {{.Section | humanize}} — {{ .Site.Title }}
     </title>

--- a/static/js/runnable.js
+++ b/static/js/runnable.js
@@ -307,7 +307,7 @@ function eraseCookie(name) {
 
     var startTime;
     $.post({
-      url: "https://play.dgraph.io/query?latency=true",
+      url: window.DGRAPH_ENDPOINT,
       data: query,
       dataType: "json",
       beforeSend: function() {


### PR DESCRIPTION
This allows runnables to use play-master.dgraph.io when in `master` branch so that users can run code examples for new features.

**However, this might not be the best solution**

1. `master` also can break a bunch of other runnables when some things are not backwards compatible. Simply changing the endpoint to `master` does not solve this problem.

Maybe a gentle reminder that `master` doc is not stable will be a better solution. Something like:

> You are viewing documentations for `master` branch. Some code examples might not be stable.

2. Maybe this is insecure, as users can simply override the variable? Not too sure on this one.

How do you feel about it @pawanrawal?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/hugo-docs/15)
<!-- Reviewable:end -->
