### PR TITLE
Root page for documentation

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -2,8 +2,8 @@
 <html lang="en" class="js csstransforms3d">
 
 <head>
-  <meta charset="utf-8"> {{ partial "meta.html" . }} {{ .Scratch.Add "title" "" }}{{ if isset .Site.Data.titles .Title }}{{ .Scratch.Set "title" (index .Site.Data.titles .Title).title }}{{ else }}{{ .Scratch.Set "title" .Title}}{{end}}
-  <title>{{ .Scratch.Get "title" }}</title>
+  <meta charset="utf-8"> {{ partial "meta.html" . }}
+  <title>{{ .Title }}</title>
   <link href="{{ .Site.BaseURL }}/css/nucleus.css" rel="stylesheet">
   <link href="{{ .Site.BaseURL }}/css/font-awesome.min.css" rel="stylesheet">
   <link href="{{ .Site.BaseURL }}/css/hybrid.css" rel="stylesheet">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -11,16 +11,25 @@
     {{end}}
     <title>{{ .Scratch.Get "title" }}</title>
 
-    <link href="{{ .Site.BaseURL }}/css/nucleus.css" rel="stylesheet">
-    <link href="{{ .Site.BaseURL }}/css/font-awesome.min.css" rel="stylesheet">
-    <link href="{{ .Site.BaseURL }}/css/hybrid.css" rel="stylesheet">
-    <link href="{{ .Site.BaseURL }}/css/featherlight.min.css" rel="stylesheet">
-    <link href="{{ .Site.BaseURL }}/css/perfect-scrollbar.min.css" rel="stylesheet">
     <link href="{{ .Site.BaseURL }}css/theme.css?{{ now }}" rel="stylesheet">
-    <link href="{{ .Site.BaseURL }}/css/hugo-theme.css" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css?family=Lato:400,700" rel="stylesheet">
-    <meta http-equiv="refresh" content="0; url={{ .Site.BaseURL }}get-started"/>
   </head>
   <body>
+    {{ partial "header.html" . }}
+
+    <article id="{{ .Slug }}">
+      {{ partial "request-edit.html" . }}
+      {{ partial "suggest-edit.html" . }}
+
+      <h1 class="post-title">{{ .Title }}</h1>
+
+      <div>{{ .Content }}</div>
+    </article>
+
+    {{ partial "community-footer.html" . }}
+
+    {{ partial "runnable-modal.html" . }}
+
+    {{ partial "footer.html" . }}
   </body>
 </html>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -4,12 +4,7 @@
     <meta charset="utf-8">
     {{ partial "meta.html" . }}
     {{ .Scratch.Add "title" "" }}
-    {{ if isset .Site.Data.titles .Title }}
-      {{ .Scratch.Set "title" (index .Site.Data.titles .Title).title }} {{ .Site.Title }}
-    {{ else }}
-      {{ .Scratch.Set "title" .Title}}
-    {{end}}
-    <title>{{ .Scratch.Get "title" }}</title>
+    <title>{{ .Title }}</title>
 
     <link href="{{ .Site.BaseURL }}css/theme.css?{{ now }}" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css?family=Lato:400,700" rel="stylesheet">

--- a/layouts/partials/example-go-grpc.html
+++ b/layouts/partials/example-go-grpc.html
@@ -3,11 +3,13 @@
 {{/*
   Display different import paths depending on the version of Dgraph.
 
-  NOTE: $currentBranch is in a format of `release/v0.7.6` or it is `master`
+  If the branch is `master` or not in a format of `release/vx.x.x`, use default.
+  (to check for `release/vx.x.x`, here we just check if the branch name is of
+  length 14 - FIXME if better solution emerges)
 */}}
 
 {{ .Content.Scratch.Add "protoPath" "" }}
-{{ if eq $currentBranch "master" }}
+{{ if or (eq $currentBranch "master") (ne ($currentBranch | len) 14) }}
   {{ .Content.Scratch.Add "protoPath" "\"github.com/dgraph-io/dgraph/protos\"" }}
 {{ else }}
   {{ $version := slicestr $currentBranch 9 }}

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -8,7 +8,7 @@
     <select class="version-selector">
       {{ range $i, $version := $Versions }}
           {{ if eq $i 0 }}
-            <option value="{{$version}}">{{ $version }} (latest)</option>
+            <option value="">{{ $version }} (latest)</option>
           {{ else }}
             <option value="{{$version}}">{{ $version }}</option>
           {{ end }}

--- a/layouts/shortcodes/community-toc.html
+++ b/layouts/shortcodes/community-toc.html
@@ -1,0 +1,30 @@
+<section class="toc">
+  <div class="container">
+    <div class="row row-no-padding">
+      <div class="col-12 col-sm-6">
+        <div class="section-item">
+          <div class="section-name">
+            <a href="https://slack.dgraph.io">
+              Slack
+            </a>
+          </div>
+          <p class="section-desc">
+            Chat instantly to the Dgrpah community and engineers.
+          </p>
+        </div>
+      </div>
+      <div class="col-12 col-sm-6">
+        <div class="section-item">
+          <div class="section-name">
+            <a href="https://discuss.dgraph.io">
+              Forum
+            </a>
+          </div>
+          <p class="section-desc">
+            Discuss Dgraph on the official forum.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/layouts/shortcodes/resources-toc.html
+++ b/layouts/shortcodes/resources-toc.html
@@ -1,0 +1,30 @@
+<section class="toc">
+  <div class="container">
+    <div class="row row-no-padding">
+      <div class="col-12 col-sm-6">
+        <div class="section-item">
+          <div class="section-name">
+            <a href="https://tour.dgraph.io">
+              Tour of Dgraph
+            </a>
+          </div>
+          <p class="section-desc">
+            Take an interactive tour of Dgraph with real queries and real results.
+          </p>
+        </div>
+      </div>
+      <div class="col-12 col-sm-6">
+        <div class="section-item">
+          <div class="section-name">
+            <a href="https://discuss.dgraph.io">
+              Dgraph Playground
+            </a>
+          </div>
+          <p class="section-desc">
+            Play with Freebase movie dataset with 21 million edges
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/layouts/shortcodes/toc.html
+++ b/layouts/shortcodes/toc.html
@@ -1,0 +1,20 @@
+<section class="toc">
+  <div class="container">
+    <div class="row row-no-padding">
+      {{ range .Site.Menus.main }}
+        <div class="col-12 col-sm-6">
+          <div class="section-item">
+            <div class="section-name">
+              <a href="{{ .URL }}">
+                {{ .Name }}
+              </a>
+            </div>
+            <p class="section-desc">
+              {{ index $.Site.Params.menudesc .Identifier }}
+            </p>
+          </div>
+        </div>
+      {{ end }}
+    </div>
+  </div>
+</section>

--- a/static/css/runnable.css
+++ b/static/css/runnable.css
@@ -281,10 +281,6 @@ html .runnable code {
 
 
 /* custom bootstrap */
-/*.row-no-padding [class^="col-"] {
-  padding-left: 0 !important;
-  padding-right: 0 !important;
-}*/
 .runnable .nopadding {
    padding: 0 !important;
    margin: 0 !important;

--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -535,3 +535,22 @@ h1:hover .anchor i, h2:hover .anchor i, h3:hover .anchor i {
     padding: 0 13px 0 31px;
   }
 }
+
+/* table of contents in home page */
+
+section.toc .section-name {
+  font-size: 16px;
+  font-weight: 600;
+}
+section.toc .section-desc {
+  margin-bottom: 0;
+}
+section.toc .section-item {
+  margin-bottom: 8px;
+}
+
+/* custom bootstrap */
+.row-no-padding [class^="col-"] {
+  padding-left: 0 !important;
+  padding-right: 0 !important;
+}

--- a/static/js/dgraph.js
+++ b/static/js/dgraph.js
@@ -60,6 +60,39 @@ function isElementInViewport(el) {
   );
 }
 
+/**
+ * getCurrentVersion gets the current doc version from the URL path and returns it
+ *
+ * @params pathname {String} - current path in a format of '/current/path'.
+ * @return {String} - e.g. 'master', 'v7.7.1', ''
+ *                    empty string denotes the latest version
+ */
+function getCurrentVersion(pathname) {
+  const candidate = pathname.split("/")[1];
+
+  if (candidate === "master") {
+    return candidate;
+  }
+
+  if (/v\d\.\d\.\d/.test(candidate)) {
+    return candidate;
+  }
+
+  return "";
+}
+
+// getPathWithoutVersionName gets the current URL path without the version prefix
+function getPathWithoutVersionName(location, versionName) {
+  let path;
+  if (versionName === "") {
+    path = location.pathname.split("/").slice(1).join("/");
+  } else {
+    path = location.pathname.split("/").slice(2).join("/");
+  }
+
+  return path + location.hash;
+}
+
 (function() {
   // clipboard
   var clipInit = false;
@@ -294,17 +327,16 @@ function isElementInViewport(el) {
   });
 
   // version selector
-  var currentVersion = location.pathname.split("/")[1];
+  var currentVersion = getCurrentVersion(location.pathname);
   document
     .getElementsByClassName("version-selector")[0]
     .addEventListener("change", function(e) {
-      // targetVersion: '', '/v0.7.7', 'v0.7.6', etc.
+      // targetVersion: '', 'master', 'v0.7.7', 'v0.7.6', etc.
       var targetVersion = e.target.value;
 
       if (currentVersion !== targetVersion) {
         // Getting everything after targetVersion and concatenating it with the hash part.
-        var currentPath =
-          location.pathname.split("/").slice(2).join("/") + location.hash;
+        var currentPath = getPathWithoutVersionName(location, currentVersion);
 
         var targetPath;
         if (targetVersion === "") {
@@ -331,6 +363,7 @@ function isElementInViewport(el) {
       break;
     }
   }
+  ("\ ");
 
   // Add target = _blank to all external links.
   var links = document.links;

--- a/static/js/dgraph.js
+++ b/static/js/dgraph.js
@@ -15,34 +15,35 @@ function debounce(func, wait, immediate) {
     timeout = setTimeout(later, wait);
     if (callNow) func.apply(context, args);
   };
-};
+}
 
 /********** Cookie helpers **/
 
 function createCookie(name, val, days) {
-  var expires = '';
+  var expires = "";
   if (days) {
     var date = new Date();
-    date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
-    expires = '; expires=' + date.toUTCString();
+    date.setTime(date.getTime() + days * 24 * 60 * 60 * 1000);
+    expires = "; expires=" + date.toUTCString();
   }
 
-  document.cookie = name + '=' + val + expires + '; path=/';
+  document.cookie = name + "=" + val + expires + "; path=/";
 }
 
 function readCookie(name) {
-  var nameEQ = name + '=';
-  var ca = document.cookie.split(';');
+  var nameEQ = name + "=";
+  var ca = document.cookie.split(";");
   for (var i = 0; i < ca.length; i++) {
     var c = ca[i];
-    while (c.charAt(0)==' ') c = c.substring(1,c.length);
-    if (c.indexOf(nameEQ) == 0) return c.substring(nameEQ.length,c.length);
+    while (c.charAt(0) == " ")
+      c = c.substring(1, c.length);
+    if (c.indexOf(nameEQ) == 0) return c.substring(nameEQ.length, c.length);
   }
   return null;
 }
 
 function eraseCookie(name) {
-  createCookie(name, '', -1);
+  createCookie(name, "", -1);
 }
 
 // isElementInViewport checks if element is visible in the DOM
@@ -53,7 +54,8 @@ function isElementInViewport(el) {
   return (
     rect.top >= topbarOffset &&
     rect.left >= 0 &&
-    rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
+    rect.bottom <=
+      (window.innerHeight || document.documentElement.clientHeight) &&
     rect.right <= (window.innerWidth || document.documentElement.clientWidth)
   );
 }
@@ -76,11 +78,10 @@ function isElementInViewport(el) {
 
         clip.on("success", function(e) {
           e.clearSelection();
-          $(e.trigger).text("Copied to clipboard!")
-            .addClass('copied');
+          $(e.trigger).text("Copied to clipboard!").addClass("copied");
 
           window.setTimeout(function() {
-            $(e.trigger).text("Copy").removeClass('copied');
+            $(e.trigger).text("Copy").removeClass("copied");
           }, 2000);
         });
 
@@ -116,7 +117,9 @@ function isElementInViewport(el) {
     var nextH2 = h2s[i + 1];
     var ourH3s = [];
     while (
-      h3s[j] && isAfter(h2, h3s[j]) && (!nextH2 || !isAfter(nextH2, h3s[j]))
+      h3s[j] &&
+      isAfter(h2, h3s[j]) &&
+      (!nextH2 || !isAfter(nextH2, h3s[j]))
     ) {
       ourH3s.push({ header: h3s[j] });
       j++;
@@ -137,11 +140,11 @@ function isElementInViewport(el) {
 
     Array.prototype.forEach.call(headers, function(h) {
       var li = createSubtopicItem(h.header);
-      li.className = 'topic sub-topic';
+      li.className = "topic sub-topic";
       subMenu.appendChild(li);
 
       if (h.subHeaders) {
-        createSubtopic(subMenu, h.subHeaders)
+        createSubtopic(subMenu, h.subHeaders);
       }
     });
   }
@@ -150,7 +153,8 @@ function isElementInViewport(el) {
     allLinks.push(h);
 
     var li = document.createElement("li");
-    li.innerHTML = '<i class="fa fa-angle-right"></i> <a href="#' +
+    li.innerHTML =
+      '<i class="fa fa-angle-right"></i> <a href="#' +
       h.id +
       '" data-scroll class="' +
       h.tagName +
@@ -165,14 +169,16 @@ function isElementInViewport(el) {
   // @params hash [String] - hash including the hash sign at the beginning
   function setActiveSubTopic(hash) {
     // Set inactive the previously active topic
-    var prevActiveTopic = document.querySelector('.sub-topics .topic.active');
-    var nextActiveTopic = document.querySelector('.sub-topics a[href="' + hash + '"]').parentNode;
+    var prevActiveTopic = document.querySelector(".sub-topics .topic.active");
+    var nextActiveTopic = document.querySelector(
+      '.sub-topics a[href="' + hash + '"]'
+    ).parentNode;
 
     if (prevActiveTopic !== nextActiveTopic) {
-      nextActiveTopic.classList.add('active');
+      nextActiveTopic.classList.add("active");
 
       if (prevActiveTopic) {
-        prevActiveTopic.classList.remove('active');
+        prevActiveTopic.classList.remove("active");
       }
     }
   }
@@ -185,7 +191,7 @@ function isElementInViewport(el) {
     var activeHash;
     for (var i = 0; i < allLinks.length; i++) {
       var h = allLinks[i];
-      var hash = h.getElementsByTagName('a')[0].hash;
+      var hash = h.getElementsByTagName("a")[0].hash;
 
       if (h.offsetTop - topSideOffset > currentScrollY) {
         if (!activeHash) {
@@ -202,65 +208,68 @@ function isElementInViewport(el) {
     }
   }
 
-  if (h2sWithH3s.length > 0) {
+  if (h2sWithH3s.length > 0 && activeLink) {
     createSubtopic(activeLink, h2sWithH3s);
   }
 
-  var subTopics = document.querySelectorAll('.sub-topics .sub-topic')
+  var subTopics = document.querySelectorAll(".sub-topics .sub-topic");
   for (var i = 0; i < subTopics.length; i++) {
-    var subTopic = subTopics[i]
-    subTopic.addEventListener('click', function (e) {
+    var subTopic = subTopics[i];
+    subTopic.addEventListener("click", function(e) {
       var hash = e.target.hash;
       setActiveSubTopic(hash);
     });
   }
 
   // Scrollspy for sidebar
-  window.addEventListener('scroll', debounce(updateSidebar, 15));
+  window.addEventListener("scroll", debounce(updateSidebar, 15));
 
   // Sidebar toggle
-  document.getElementById('sidebar-toggle').addEventListener('click', function (e) {
-    e.preventDefault();
-    var klass = document.body.className;
-    if (klass === "sidebar-visible") {
-      document.body.className = "";
-    } else {
-      document.body.className = "sidebar-visible";
-    }
-  });
+  document
+    .getElementById("sidebar-toggle")
+    .addEventListener("click", function(e) {
+      e.preventDefault();
+      var klass = document.body.className;
+      if (klass === "sidebar-visible") {
+        document.body.className = "";
+      } else {
+        document.body.className = "sidebar-visible";
+      }
+    });
 
   // Anchor tags for headings
   function appendAnchor(heading) {
     var id = heading.id;
-    var anchorOffset = document.createElement('div');
-    anchorOffset.className = 'anchor-offset';
+    var anchorOffset = document.createElement("div");
+    anchorOffset.className = "anchor-offset";
     anchorOffset.id = id;
 
     var anchor = document.createElement("a");
-    anchor.href = '#' + id;
-    anchor.className = 'anchor';
+    anchor.href = "#" + id;
+    anchor.className = "anchor";
     // anchor.innerHTML = 'link'
-    anchor.innerHTML = '<i class="fa fa-link"></i>'
+    anchor.innerHTML = '<i class="fa fa-link"></i>';
     heading.insertBefore(anchor, heading.firstChild);
     heading.insertBefore(anchorOffset, heading.firstChild);
 
     // Remove the id from heading
     // Instead we will assign the id to the .anchor-offset element to account
     // for the fixed header height
-    heading.removeAttribute('id');
+    heading.removeAttribute("id");
   }
   var h2s = document.querySelectorAll(
-    '.content-wrapper h2, .content-wrapper h3');
+    ".content-wrapper h2, .content-wrapper h3"
+  );
   for (var i = 0; i < h2s.length; i++) {
     appendAnchor(h2s[i]);
   }
 
   // code collapse
-  var pres = $('pre');
+  var pres = $("pre");
   pres.each(function() {
     var self = this;
 
-    var isInRunnable = $(self).parents('.runnable').length > 0;
+    var isInRunnable = $(self).parents(".runnable").length > 0;
     if (isInRunnable) {
       return;
     }
@@ -282,7 +291,6 @@ function isElementInViewport(el) {
 
       this.appendChild(showMore);
     }
-
   });
 
   // version selector
@@ -294,7 +302,8 @@ function isElementInViewport(el) {
 
       if (currentVersion !== targetVersion) {
         // Getting everything after targetVersion and concatenating it with the hash part.
-        var targetPath = "/" +
+        var targetPath =
+          "/" +
           targetVersion +
           "/" +
           location.pathname.split("/").slice(2).join("/") +
@@ -329,22 +338,26 @@ function isElementInViewport(el) {
   }
 
   // Community selector
-  $(document).on('click', '.community-cta', function (e) {
+  $(document).on("click", ".community-cta", function(e) {
     e.stopPropagation();
     e.preventDefault();
-    $(this).closest('.community-cta-wrapper').toggleClass('open');
+    $(this).closest(".community-cta-wrapper").toggleClass("open");
   });
 
-  $(document).on('click', '.community-link', function (e) {
+  $(document).on("click", ".community-link", function(e) {
     e.stopPropagation();
-    $(this).closest('.community-cta-wrapper').toggleClass('open');
+    $(this).closest(".community-cta-wrapper").toggleClass("open");
   });
 
-  $(document).click(function () {
-    $('.community-cta-wrapper').removeClass('open');
+  $(document).click(function() {
+    $(".community-cta-wrapper").removeClass("open");
   });
 
   /********** On page load **/
   updateSidebar();
-  document.querySelector('.sub-topics .topic.active').scrollIntoView();
+  var activeTopic = document.querySelector(".sub-topics .topic.active");
+
+  if (activeTopic) {
+    activeTopic.scrollIntoView();
+  }
 })();

--- a/static/js/dgraph.js
+++ b/static/js/dgraph.js
@@ -298,16 +298,20 @@ function isElementInViewport(el) {
   document
     .getElementsByClassName("version-selector")[0]
     .addEventListener("change", function(e) {
+      // targetVersion: '', '/v0.7.7', 'v0.7.6', etc.
       var targetVersion = e.target.value;
 
       if (currentVersion !== targetVersion) {
         // Getting everything after targetVersion and concatenating it with the hash part.
-        var targetPath =
-          "/" +
-          targetVersion +
-          "/" +
-          location.pathname.split("/").slice(2).join("/") +
-          location.hash;
+        var currentPath =
+          location.pathname.split("/").slice(2).join("/") + location.hash;
+
+        var targetPath;
+        if (targetVersion === "") {
+          targetPath = "/" + currentPath;
+        } else {
+          targetPath = "/" + targetVersion + "/" + currentPath;
+        }
         location.assign(targetPath);
       }
     });


### PR DESCRIPTION
DO NOT MERGE BEFORE https://github.com/dgraph-io/dgraph/pull/1037

* Adds the root page for documentation at `https://doc.dgraph.io/`
  * Currently we do HTML meta redirect from the root page to versioned page which is bad for SEO
* Latest version of the doc is accessible directly from the root, and archived docs are accessible using version prefix in the URL

e.g. `https://doc.dgraph.io/query-language`, `https://doc.dgraph.io/v7.7.4/query-language`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/hugo-docs/16)
<!-- Reviewable:end -->
