### PR TITLE
Render notice messages as Markdown.

### DIFF
--- a/layouts/shortcodes/notice.html
+++ b/layouts/shortcodes/notice.html
@@ -1,5 +1,5 @@
 {{ $type := .Get 0}}
 
 <div class="notices {{ $type }}" {{ if len .Params | eq 2 }} id="{{ .Get 1 }}" {{ end }}>
-  <span class="type">{{ humanize $type }}</span> {{ .Inner }}
+  <span class="type">{{ humanize $type }}</span> {{ .Inner | markdownify }}
 </div>


### PR DESCRIPTION
We're now using Hugo v0.58.3 (used to be v0.39) to serve https://docs.dgraph.io, and the notice messages started to not render as Markdown anymore. This change should fix that.

Before:
![image](https://user-images.githubusercontent.com/2251820/65353171-4ed04380-dba1-11e9-9f06-47549a27e9bd.png)

After:
![image](https://user-images.githubusercontent.com/2251820/65353181-57c11500-dba1-11e9-8937-35811b799a8b.png)


Not 100% sure `| markdownify` is the right solution, but it works.

More info: https://discourse.gohugo.io/t/misunderstanding-of-shortcode-syntax-in-0-55/18538

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/hugo-docs/38)
<!-- Reviewable:end -->
