### PR TITLE
Updated example code partials

### DIFF
--- a/layouts/partials/example-go-grpc.html
+++ b/layouts/partials/example-go-grpc.html
@@ -10,50 +10,45 @@
 {{ $majorVersion := int (index $version 0) }}
 {{ $minorVersion := int (index $version 1) }}
 {{ $patchVersion := int (index $version 2) }}
-{{ $versionGe105 := or (eq $currentBranch "master") (gt $majorVersion 1) (and (eq $majorVersion 1) (gt $minorVersion 0)) (and (eq $majorVersion 1) (eq $minorVersion 0) (ge $patchVersion 5)) }}
+{{ $versionGe110 := or (eq $currentBranch "master") (gt $majorVersion 1) (and (eq $majorVersion 1) (gt $minorVersion 1)) (and (eq $majorVersion 1) (ge $minorVersion 1) (ge $patchVersion 0)) }}
 
 <pre><code class="no-copy" tabindex="-1">package main
 
 import (
-  "context"
-  "flag"
-  "fmt"
-  "log"
-
-  {{- if $versionGe105 }}
-  "github.com/dgraph-io/dgo"
-  "github.com/dgraph-io/dgo/protos/api"
-  {{ else }}
-  "github.com/dgraph-io/dgraph/client"
-  "github.com/dgraph-io/dgraph/protos/api"
-  {{ end -}}
-  "google.golang.org/grpc"
+	"context"
+	"flag"
+	"fmt"
+	"log"
+    {{ if $versionGe110 }}
+	"github.com/dgraph-io/dgo/v2"
+	"github.com/dgraph-io/dgo/v2/protos/api"
+    {{ else }}
+	"github.com/dgraph-io/dgo"
+	"github.com/dgraph-io/dgo/protos/api"
+    {{ end }}
+	"google.golang.org/grpc"
 )
 
 var (
-  dgraph = flag.String("d", "127.0.0.1:9080", "Dgraph Alpha address")
+	dgraph = flag.String("d", "127.0.0.1:9080", "Dgraph Alpha address")
 )
 
 func main() {
-  flag.Parse()
-  conn, err := grpc.Dial(*dgraph, grpc.WithInsecure())
-  if err != nil {
-    log.Fatal(err)
-  }
-  defer conn.Close()
+	flag.Parse()
+	conn, err := grpc.Dial(*dgraph, grpc.WithInsecure())
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer conn.Close()
 
-  {{ if $versionGe105 }}
-  dg := dgo.NewDgraphClient(api.NewDgraphClient(conn))
-  {{ else }}
-  dg := client.NewDgraphClient(api.NewDgraphClient(conn))
-  {{ end }}
-  {{ if eq .Vars nil }}
-  resp, err := dg.NewTxn().Query(context.Background(), `<span class="query-content">{{ .Code }}</span>`)
-  {{ else }}
-  resp, err := dg.NewTxn().QueryWithVars(context.Background(), `<span class="query-content">{{ .Code }}</span>`, map[string]string{{ .Vars }})
-  {{ end }}
-  if err != nil {
-    log.Fatal(err)
-  }
-  fmt.Printf("Response: %s\n", resp.Json)
+	dg := dgo.NewDgraphClient(api.NewDgraphClient(conn))
+    {{ if eq .Vars nil }}
+	resp, err := dg.NewTxn().Query(context.Background(), `<span class="query-content">{{ .Code }}</span>`)
+	{{ else }}
+	resp, err := dg.NewTxn().QueryWithVars(context.Background(), `<span class="query-content">{{ .Code }}</span>`, map[string]string{{ .Vars }})
+    {{ end }}
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("Response: %s\n", resp.Json)
 }</code></pre>

--- a/layouts/partials/example-js-grpc.html
+++ b/layouts/partials/example-js-grpc.html
@@ -12,14 +12,16 @@ const grpc = require("grpc");
 async function main() {
   const clientStub = new dgraph.DgraphClientStub("localhost:9080", grpc.credentials.createInsecure());
   const dgraphClient = new dgraph.DgraphClient(clientStub);
+
   const query = `<span class="query-content">{{ .Code }}</span>`;
-{{ if eq .Vars nil }}
+  {{- if eq .Vars nil }}
   const response = await dgraphClient.newTxn().query(query);
-{{ else }}
+  {{ else }}
   const vars = {{ .Vars }};
   const response = await dgraphClient.newTxn().queryWithVars(query, vars);
-{{ end }}
+  {{ end -}}
   console.log("Response: ", JSON.stringify(response.getJson()));
+
   clientStub.close();
 }
 

--- a/layouts/partials/example-js-http.html
+++ b/layouts/partials/example-js-http.html
@@ -11,13 +11,14 @@
 async function main() {
   const clientStub = new dgraph.DgraphClientStub("http://localhost:8080");
   const dgraphClient = new dgraph.DgraphClient(clientStub);
+
   const query = `<span class="query-content">{{ .Code }}</span>`;
-{{ if eq .Vars nil }}
+  {{- if eq .Vars nil }}
   const response = await dgraphClient.newTxn().query(query);
-{{ else }}
+  {{ else }}
   const vars = {{ .Vars }};
   const response = await dgraphClient.newTxn().queryWithVars(query, vars);
-{{ end }}
+  {{ end -}}
   console.log("Response: ", JSON.stringify(response.data));
 }
 

--- a/layouts/partials/example-python.html
+++ b/layouts/partials/example-python.html
@@ -9,23 +9,17 @@
 <pre><code class="no-copy" tabindex="-1">import pydgraph
 import json
 
-def query_data(client):
-
-    query = """<span class="query-content">{{ .Code }}</span>"""
-
-{{ if eq .Vars nil }}
-    res = client.txn(read_only=True).query(query)
-{{ else }}
-    variables = {{ .Vars }}
-    res = client.txn(read_only=True).query(query, variables=variables)
-{{ end }}
-
-    print('Response: {}'.format(json.loads(res.json)))
-
 def main():
     client_stub = pydgraph.DgraphClientStub("localhost:9080")
     client = pydgraph.DgraphClient(client_stub)
-    query_data(client)
+    query = """<span class="query-content">{{ .Code }}</span>"""
+    {{- if eq .Vars nil }}
+    res = client.txn(read_only=True).query(query)
+    {{ else }}
+    variables = {{ .Vars }}
+    res = client.txn(read_only=True).query(query, variables=variables)
+    {{ end -}}
+    print('Response: {}'.format(json.loads(res.json)))
 
     client_stub.close()
 


### PR DESCRIPTION
- Added logic to use dgo v2 for Dgraph master and v1.1.0
- Better formatting for all example codes
- Since docs site has deprecated documentation for Dgraph versions before v1.0.6. Removing the logic of supporting them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/hugo-docs/41)
<!-- Reviewable:end -->
