### PR TITLE
fix(search): use correct versioning resolves algolia/docsearch-configs#1857

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -7,7 +7,7 @@
       if (window.docsearch) {
         var version = 'latest';
         var path = window.location.pathname;
-        var arr = /^(?:\/)?((?:master)|(?:v[0-9][^\/]+))(?:\/)?.*$/.exec(path);
+        var arr = /(?:\/)?((?:master)|(?:v[0-9][^\/]+))(?:\/)?.*$/.exec(path);
         if (arr != null && arr.length > 1) {
           version = arr[1];
         }


### PR DESCRIPTION
`window.location.pathname ` now starts with `/docs/`. We need to remove the start token. It will solves the versioning issue

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/hugo-docs/46)
<!-- Reviewable:end -->
