### PR TITLE
Fix version selector to work with calendar versioning.

### DIFF
--- a/static/js/dgraph.js
+++ b/static/js/dgraph.js
@@ -66,7 +66,7 @@ function getCurrentVersion(pathname) {
     return candidate;
   }
 
-  if (/v\d\.\d\.\d/.test(candidate)) {
+  if (/v\d+\.\d+\.\d+/.test(candidate)) {
     return candidate;
   }
 


### PR DESCRIPTION
This changes the `getCurrentVersion` regexp to match on versions that fit our calendar versioning scheme of `vYY.MM.PATCH`, e.g., `v20.03.0`.

Before, we were only matching on single-digit major/minor/patch version numbers, so `getCurrentVersion` was returning empty instead of the correct current version when the version is a calendar version.

This fixes the version selector that can incorrectly set the URL to a 404 page. e.g., starting from v20.03.0 and going to master results in a 404 to `https://dgraph.io/docs/master/v20.03.0/`. It should go to `https://dgraph.io/docs/master`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/hugo-docs/49)
<!-- Reviewable:end -->
