### PR TITLE
Fix: Redirects for subpages.

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -388,8 +388,8 @@
         console.log(subPaths[origPath]);
         location.href = "{{ .Site.BaseURL }}" + subPaths[origPath];
       }
-      else if (urlSplit[1]) {
-        location.href = "/" + pathSplit[3] + "/" + urlSplit[1];
+      else if (urlSplit[1]) { // an anchor tag
+        location.href = "{{ .Site.BaseURL }}" + "/" + pathSplit[4] + "/" + urlSplit[1];
       }
     }
   </script>


### PR DESCRIPTION
Redirects for the new subpages work like this:

Original URL: https://dgraph.io/docs/deploy/#ports-usage
Redirect URL: https://dgraph.io/docs/deploy/ports-usage

We remove the anchor tag (#ports-usage) and redirect to the corresponding page with the same name as the old anchor (/ports-usage).

The original code didn't work when the docs are served on a subpage (/docs).