### PR TITLE
fix(runnable): Fix runnable blocks 404-ing.

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -440,7 +440,7 @@
     {{ $currentBranch:= getenv "CURRENT_BRANCH" }}
     {{ $dgraphEndpoint:= getenv "DGRAPH_ENDPOINT" }}
 
-    window.DGRAPH_ENDPOINT = {{ if (eq $dgraphEndpoint "" ) }}"https://play.dgraph.io/query?latency=true"{{ else }} {{ $dgraphEndpoint }} {{ end }}
+    window.DGRAPH_ENDPOINT = {{ if (eq $dgraphEndpoint "" ) }}"https://play.dgraph.io/query?latency=true"{{ else }} {{ $dgraphEndpoint }} {{ end }};
     
     (function(h,o,t,j,a,r){
               h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};


### PR DESCRIPTION
This adds a semi-colon to terminate the variable declaration for DGRAPH_ENDPOINT
used for runnables.

The variable declaration for `window.DGRAPH_ENDPOINT` needs to end in a
semi-colon or else it gets interpreted as a function call with the next line in
the script.

    Uncaught TypeError: "https://play.dgraph.io/query?latency=true" is not a function
        at (index):451

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/hugo-docs/66)
<!-- Reviewable:end -->
