### PR TITLE
feat: Supporting Nesting

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -38,6 +38,15 @@
                       <li class="topic sub-topic{{if or ($currentPage.IsMenuCurrent "main" .) ($currentPage.HasMenuCurrent "main" .) }} active{{end}}">
                         {{/*  <i class="fa fa-angle-right"></i>  */}}
                           <a href="{{ .URL }}">{{ .Name }}</a>
+                          {{ if .HasChildren }}
+                          <ul class="sub-topics">
+                            {{ range .Children }}
+                              <li class="topic sub-topic{{if or ($currentPage.IsMenuCurrent "main" .) ($currentPage.HasMenuCurrent "main" .) }} active{{end}}">
+                                <a href="{{ .URL }}">{{ .Name }}</a>
+                              </li>
+                            {{ end }}
+                          </ul>
+                          {{ end }}
                       </li>
                   {{ end }}
               </ul>
@@ -61,7 +70,7 @@
     <li>
       <a href="https://discuss.dgraph.io/" target="_blank">Community</a>
     </li>
-  
+
     <li>
       <a href="https://github.com/dgraph-io/dgraph" target="_blank">GitHub</a>
     </li>

--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -532,6 +532,11 @@ pre.collapsed .showmore span {
   font-weight: 400;
 }
 
+/* Children menus are always open */
+.sub-topics .sub-topics {
+  display: block;
+}
+
 .topic.active > .sub-topics {
   display: block;
 }


### PR DESCRIPTION
In order to do nesting, set 'identifier' on the parent, and use 'parent' as usual on the child

Here are some screenshots. I didn't put any indicator of the child other than indenting (since I don't think another menu would look good).

It highlights the path to the child.

![image](https://user-images.githubusercontent.com/34746/90057662-568b6000-dcfe-11ea-9f04-efbafdc7df3a.png)

![image](https://user-images.githubusercontent.com/34746/90057628-496e7100-dcfe-11ea-95fa-e058e6f06789.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/hugo-docs/67)
<!-- Reviewable:end -->
