### PR TITLE
Adding support for Discourse Comments

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -17,15 +17,19 @@
 {{ end }}
 <div class="top-toc">
   {{ .TableOfContents }}
-  </div>
-<article id="{{ .Slug }}">
-  {{ partial "request-edit.html" . }}
-  {{ partial "suggest-edit.html" . }}
+</div>
+<div>
+  <article id="{{ .Slug }}">
+    {{ partial "request-edit.html" . }}
+    {{ partial "suggest-edit.html" . }}
 
-  <h1 class="post-title">{{ .Title }}</h1>
+    <h1 class="post-title">{{ .Title }}</h1>
 
-  <div>{{ .Content }}</div>
-</article>
+    <div>{{ .Content }}</div>
+
+    {{ partial "post_comments.html" . }}
+  </article>
+</div>
 
 {{ if not .Sections }}
 <div class="right-toc">

--- a/layouts/partials/canonical.html
+++ b/layouts/partials/canonical.html
@@ -1,0 +1,5 @@
+{{- $canonicalUrl := string .Permalink -}}
+{{- if (ne (getenv "CANONICAL_PATH") "") -}}
+{{- $canonicalUrl = (replace $canonicalUrl (trim .Site.BaseURL "/") (trim (getenv "CANONICAL_PATH") "/")) -}}
+{{- end -}}
+{{- $canonicalUrl -}}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -397,11 +397,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
   {{ .Hugo.Generator }}
   {{ partial "meta.html" . }}
-  {{ $canonicalUrl := string .Permalink }}
-  {{ if (ne (getenv "CANONICAL_PATH") "") }}
-  {{ $canonicalUrl = (replace $canonicalUrl (trim .Site.BaseURL "/") (trim (getenv "CANONICAL_PATH") "/")) }}
-  {{ end }}
-  <link rel="canonical" href="{{ $canonicalUrl }}" />
+  <link rel="canonical" href="{{ partial "canonical.html" . }}" />
 
   <link rel="apple-touch-icon" sizes="57x57" href="/images/favicons/apple-touch-icon-57x57.png">
   <link rel="apple-touch-icon" sizes="60x60" href="/images/favicons/apple-touch-icon-60x60.png">

--- a/layouts/partials/post_comments.html
+++ b/layouts/partials/post_comments.html
@@ -9,7 +9,7 @@
             {{ if .Params.discuss -}}
             topicId: {{ .Params.discuss }}
             {{ else -}}
-            discourseEmbedUrl: "{{ .Permalink }}"
+            discourseEmbedUrl: "{{ partial "canonical.html" . }}"
             {{ end -}}
         };
         (function() {

--- a/layouts/partials/post_comments.html
+++ b/layouts/partials/post_comments.html
@@ -1,0 +1,26 @@
+<div class="post__comments">
+
+    <div id="discourse-comments"></div>
+
+    {{if .Site.Params.discourse}}
+    <script type="text/javascript">
+        DiscourseEmbed = {
+            discourseUrl: "{{.Site.Params.discourse}}",
+            {{ if .Params.discuss -}}
+            topicId: {{ .Params.discuss }}
+            {{ else -}}
+            discourseEmbedUrl: "{{ .Permalink }}"
+            {{ end -}}
+        };
+        (function() {
+            var d = document.createElement("script");
+            d.type = "text/javascript";
+            d.async = true;
+            d.src = DiscourseEmbed.discourseUrl + "javascripts/embed.js";
+            (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(d);
+        })();
+    </script>
+    <noscript>Please enable JavaScript to view the comments on <a href="{{.Site.Params.discourse}}">discuss</a>.</noscript>
+    {{end}}
+
+</div>

--- a/layouts/partials/post_comments.html
+++ b/layouts/partials/post_comments.html
@@ -2,7 +2,7 @@
 
     <div id="discourse-comments"></div>
 
-    {{if .Site.Params.discourse}}
+    {{if (and .Site.Params.discourse (eq "Fetching and Updating Your Schema" .Page.Title))}}
     <script type="text/javascript">
         DiscourseEmbed = {
             discourseUrl: "{{.Site.Params.discourse}}",


### PR DESCRIPTION
I have not tested this out or merged this, since I think it will create posts on discuss as soon as it goes live. Thus, we should launch the new docs site before we continue work on this

If setting this up, please add the following to your config.toml
```toml
[params]
  discourse = "https://discuss.dgraph.io/"
```

Guide to doing this here: https://meta.discourse.org/t/embedding-discourse-comments-via-javascript/31963
But honestly, I just ripped post_comments.html off from dgaph-io/open

Screenshot (it's just the loading page because I need to set it up on discuss)
![image](https://user-images.githubusercontent.com/34746/90098207-54082500-dd55-11ea-9773-e0ebebd5db68.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/hugo-docs/68)
<!-- Reviewable:end -->
