### PR TITLE
fix redirect in export-database

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -112,7 +112,7 @@
       "/deploy/#whitelisting-admin-operations": "/deploy/dgraph-administration/#whitelisting-admin-operations",
       "/deploy/#restricting-mutation-operations": "/deploy/dgraph-administration/#restricting-mutation-operations",
       "/deploy/#securing-alter-operations": "/deploy/dgraph-administration/#securing-alter-operations",
-      "/deploy/#exporting-database": "/deploy/dgraph-administration/#exporting-database",
+      "/deploy/#export-database": "/deploy/dgraph-administration/#exporting-database",
       "/deploy/#encrypting-exports": "/deploy/dgraph-administration/#encrypting-exports",
       "/deploy/#shutting-down-database": "/deploy/dgraph-administration/#shutting-down-database",
       "/deploy/#deleting-database": "/deploy/dgraph-administration/#deleting-database",


### PR DESCRIPTION
This PR fixes the typo in redirects. 
[https://docs.dgraph.io/deploy/#export-database](https://docs.dgraph.io/deploy/#export-database) link is broken.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/hugo-docs/69)
<!-- Reviewable:end -->
