### PR TITLE
Add scroll for overflow in right toc

### DIFF
--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -198,6 +198,8 @@ div.top-toc #TableOfContents > ul:before {
 
   div.right-toc #TableOfContents {
     position: fixed;
+    max-height: 85vh;
+    overflow-y: auto;
   }
 }
 article {


### PR DESCRIPTION
Fixes DGRAPH-2313. Adds scroll to right toc so it's visible on pages like this - https://dgraph.io/docs/query-language/functions/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/hugo-docs/78)
<!-- Reviewable:end -->
