### PR TITLE
docs: Add navigation prev/next buttons

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -27,6 +27,7 @@
 
   <div>{{ .Content }}</div>
 
+  {{ partial "navigation.html" . }}
   {{ partial "post_comments.html" . }}
 </article>
 

--- a/layouts/partials/navigation.html
+++ b/layouts/partials/navigation.html
@@ -1,0 +1,8 @@
+    <div class="navigation-buttons">
+      {{if .NextInSection}}
+        <div><a class="nav-prev-btn" href="{{.NextInSection.Permalink}}">← {{.NextInSection.Title}} </a></div>
+      {{end}}
+      {{if .PrevInSection}}
+        <div><a class="nav-next-btn" href="{{.PrevInSection.Permalink}}">{{.PrevInSection.Title}} →</a></div>
+      {{end}}
+    </div>

--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -593,6 +593,17 @@ h3:hover .anchor i {
   top: -83px;
   visibility: hidden;
 }
+.nav-prev-btn {
+  float: left;
+  text-decoration: none;
+  border: 1px solid #d6d6d6;
+  border-radius: 2px;
+  padding: 2px 9px;
+  color: #5d5d5d;
+  font-size: 12px;
+  margin: 8px 4px;
+}
+.nav-next-btn,
 .edit-btn {
   float: right;
   text-decoration: none;
@@ -603,10 +614,14 @@ h3:hover .anchor i {
   font-size: 12px;
   margin: 8px 4px;
 }
+.nav-prev-btn:hover,
+.nav-next-btn:hover,
 .edit-btn:hover {
   color: #333333;
   box-shadow: 0px 0px 0.5px 0px #888888;
 }
+.nav-prev-btn .fa,
+.nav-next-btn .fa,
 .edit-btn .fa {
   margin-right: 3px;
 }

--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -139,6 +139,12 @@ html p {
   }
 }
 
+div.navigation-buttons {
+  border: 1px solid #d6d6d6;
+  margin-top: 20px;
+  margin-bottom: 58px;
+}
+
 div.top-toc {
   display: block;
   max-width: 500px;


### PR DESCRIPTION
Fixes DGRAPH-2375

This PR adds a previous and next button at the end of each article

This PR requires: https://github.com/dgraph-io/dgraph/pull/6630

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/hugo-docs/79)
<!-- Reviewable:end -->
