### PR TITLE
Docs (DQL) Update CURL example commands generated using Runnable from "graphql+-" to "dql"

### DIFF
--- a/layouts/partials/example-curl.html
+++ b/layouts/partials/example-curl.html
@@ -9,7 +9,7 @@
 
 {{ if or (eq $currentBranch "master") (not $useOldHttpApi) }}
     {{ if eq ( .Vars ) nil }}
-        <pre><code class="no-copy" tabindex="-1">curl -H "Content-Type: application/graphql+-" localhost:8080/query -XPOST -d '<br/><span class="query-content">{{ .Code }}</span>' | python -m json.tool | less
+        <pre><code class="no-copy" tabindex="-1">curl -H "Content-Type: application/dql" localhost:8080/query -XPOST -d '<br/><span class="query-content">{{ .Code }}</span>' | python -m json.tool | less
         </code></pre>
     {{ else }}
         <pre><code class="no-copy" tabindex="-1">curl -H "Content-Type: application/json" localhost:8080/query -XPOST -d '{


### PR DESCRIPTION
The CURL syntax blocks on the following page show "Content-Type: application/graphql+-" when you click "CURL":

https://dgraph.io/docs/query-language/graphql-fundamentals/

This PR changes this to show "Content-Type: application/dql".

Fixes SUCCESS-129

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/hugo-docs/81)
<!-- Reviewable:end -->
