### PR TITLE
Add tabs for json/rdf examples

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -459,6 +459,8 @@
     rel="stylesheet" />
   <link href='{{ .Site.BaseURL }}/css/runnable.css?{{ md5 (readFile "themes/hugo-docs/static/css/runnable.css") }}'
     rel="stylesheet" />
+  <link href='{{ .Site.BaseURL }}/css/tabs.css?{{ md5 (readFile "themes/hugo-docs/static/css/tabs.css") }}'
+    rel="stylesheet" />
   <link href="//maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" rel="stylesheet"
     integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
   <script src="//cdnjs.cloudflare.com/ajax/libs/tether/1.4.0/js/tether.min.js"

--- a/layouts/shortcodes/tabs.html
+++ b/layouts/shortcodes/tabs.html
@@ -1,0 +1,21 @@
+{{ $type := .Get 0}}
+
+{{ if eq $type "json" }}
+<div class="tabbed">
+  <input name="tabbed" id="tabbed-{{ $type }}" type="radio" checked>
+{{ else }}
+  <input name="tabbed" id="tabbed-{{ $type }}" type="radio">
+{{ end }}
+
+  <section>
+    <h1>
+      <label for="tabbed-{{ $type }}">{{ upper $type }}</label>
+    </h1>
+    <div>
+	{{ .Inner | markdownify }}
+    </div>
+  </section>
+
+{{ if eq $type "rdf" }}
+</div>
+{{ end }}

--- a/static/css/tabs.css
+++ b/static/css/tabs.css
@@ -1,0 +1,61 @@
+.tabbed{
+  float : left;
+  width : 100%;
+}
+
+.tabbed > input{
+  display : none;
+}
+
+.tabbed > section > h1{
+  float       : left;
+  box-sizing  : border-box;
+  margin      : 0;
+  padding     : 0.5em 0.5em 0;
+  overflow    : hidden;
+  font-size   : 1em;
+  font-weight : normal;
+}
+
+.tabbed > input:first-child + section > h1{
+  padding-left : 1em;
+}
+
+.tabbed > section > h1 > label{
+  display                 : block;
+  padding                 : 0.45em 0.75em;
+  border                  : 1px solid #ddd;
+  border-bottom           : none;
+  border-top-left-radius  : 4px;
+  border-top-right-radius : 4px;
+  box-shadow              : 0 0 0.5em rgba(0,0,0,0.0625);
+  background              : #fff;
+  cursor                  : pointer;
+     -moz-user-select     : none;
+      -ms-user-select     : none;
+  -webkit-user-select     : none;
+}
+
+.tabbed > section > div{
+  position      : relative;
+  z-index       : 1;
+  float         : right;
+  box-sizing    : border-box;
+  width         : 100%;
+  margin        : 2.5em 0 0 -100%;
+  padding       : 0.5em 0.75em;
+  border        : 1px solid #ddd;
+  border-radius : 4px;
+  box-shadow    : 0 0 0.5em rgba(0,0,0,0.0625);
+  background    : #fff;
+}
+
+.tabbed > input:checked + section > h1{
+  position : relative;
+  color    : #bd4147;
+  z-index  : 2;
+}
+
+.tabbed > input:not(:checked) + section > div{
+  display : none;
+}


### PR DESCRIPTION
Fixes DOC-162

Add a shortcode `tabs` to present JSON and RDF examples side by side (in tabs)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/hugo-docs/88)
<!-- Reviewable:end -->
