### PR TITLE
Fix: Remove capitalization from doc titles

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -453,7 +453,7 @@
           })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
   </script>
 
-  <title>{{ .Page.Title }} - {{.Section | default "Dgraph Documentation" | humanize}}</title>
+  <title>{{ .Page.Title }} - {{.Section | default "Dgraph Documentation"}}</title>
 
   <link href='{{ .Site.BaseURL }}/css/theme.css?{{ md5 (readFile "themes/hugo-docs/static/css/theme.css") }}'
     rel="stylesheet" />


### PR DESCRIPTION
This change removes the `humanize` capitalization from our docs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/hugo-docs/90)
<!-- Reviewable:end -->
