### PR TITLE
Docs (Navigation): Update version selector label, add version name for latest release, add link to Dgraph Learn and Pricing to top-nav

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -9,7 +9,7 @@
       <select class="version-selector">
         {{ range $i, $version := $Versions }}
           {{ if eq $i 0 }}
-            <option value="">{{ $version }} (latest) Rocket</option>
+            <option value="">{{ $version }} Rocket (latest)</option>
           {{ else }}
             {{ $shortVer := split $version "." }}
             {{ if ge (len $shortVer) 3 }}

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -1,25 +1,17 @@
 <aside id="sidebar">
   <div class="menu-header">
     {{ if eq .Site.Params.site "dgraph-docs" }}
-      <div class="heading">
-        Dgraph version:
-      </div>
-      {{ $VersionString := getenv "VERSIONS" }}
-      {{ $Versions := split $VersionString "," }}
-      <select class="version-selector">
-        {{ range $i, $version := $Versions }}
-          {{ if eq $i 0 }}
-            <option value="">{{ $version }} Rocket (latest)</option>
-          {{ else }}
-            {{ $shortVer := split $version "." }}
-            {{ if ge (len $shortVer) 3 }}
-              <option value="{{$version}}">{{ index $shortVer 0 }}.{{ index $shortVer 1 }}.x</option>
-            {{ else }}
-              <option value="{{$version}}">{{ $version }}</option>
-            {{ end }}
-          {{ end }}
-        {{ end }}
-      </select>
+    <div class="heading">
+      Dgraph version:
+    </div>
+    {{ $VersionString := getenv "VERSIONS" }}
+    {{ $Versions := split $VersionString "," }}
+    <select class="version-selector">
+      <option value="">v21.03 Rocket (latest)</option>
+      <option value="v20.11">v20.11 Shuri</option>
+      <option value="v20.07">v20.07 T'Challa</option>
+      <option value="master">master</option>
+    </select>   
     {{ end }}
   </div>
 

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -2,14 +2,14 @@
   <div class="menu-header">
     {{ if eq .Site.Params.site "dgraph-docs" }}
       <div class="heading">
-        Dgraph manual
+        Dgraph version:
       </div>
       {{ $VersionString := getenv "VERSIONS" }}
       {{ $Versions := split $VersionString "," }}
       <select class="version-selector">
         {{ range $i, $version := $Versions }}
           {{ if eq $i 0 }}
-            <option value="">{{ $version }} (latest)</option>
+            <option value="">{{ $version }} (latest) Rocket</option>
           {{ else }}
             {{ $shortVer := split $version "." }}
             {{ if ge (len $shortVer) 3 }}

--- a/layouts/partials/topbar.html
+++ b/layouts/partials/topbar.html
@@ -33,6 +33,9 @@
           <a href="https://dgraph.io/" target="_blank">Home</a>
         </li>
         <li>
+          <a href="https://dgraph.io/learn" target="_blank">Learn</a>
+        </li>
+        <li>
           <a href="https://dgraph.io/tour/" target="_blank">Tour</a>
         </li>
         <li>

--- a/layouts/partials/topbar.html
+++ b/layouts/partials/topbar.html
@@ -36,7 +36,10 @@
           <a href="https://dgraph.io/learn" target="_blank">Learn</a>
         </li>
         <li>
-          <a href="https://dgraph.io/tour/" target="_blank">Tour</a>
+          <a href="https://dgraph.io/tour" target="_blank">Tour</a>
+        </li>
+        <li>
+          <a href="https://dgraph.io/pricing" target="_blank">Pricing</a>
         </li>
         <li>
           <a href="https://discuss.dgraph.io/" target="_blank">Community</a>


### PR DESCRIPTION
Per feedback provided, we should change the "Dgraph manual:" label for the docs version selector to "Dgraph version:", and also make the following changes:
- Include the release name after the release version number in the version selector. 
- List docs for the `master` branch at the end of the list of releases.

So, this PR causes the left-nav version selector to show the following:

* 21.03 Rocket (latest)
* 20.11 Shuri
* 20.07 T'Challa
* master

Note: I implemented this by removing complexity (using a simplified version-selector), at the cost of requiring a quick update with each release to update the menu entries. Removing complexity and adding ease-of-customization to something we only update quarterly is my preference, but reviewers should consider whether they are OK with this tradeoff.

This PR also adds 'Learn" and "Pricing" to the list of prominent links on the top right side of the page (per design recommendations).

Fixes DOC-317

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/hugo-docs/102)
<!-- Reviewable:end -->
