### PR TITLE
Update sidebar.html to fix issues with on-site search

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -7,11 +7,19 @@
     {{ $VersionString := getenv "VERSIONS" }}
     {{ $Versions := split $VersionString "," }}
     <select class="version-selector">
-      <option value="">v21.03 Rocket (latest)</option>
-      <option value="v20.11">v20.11 Shuri</option>
-      <option value="v20.07">v20.07 T'Challa</option>
-      <option value="master">master</option>
-    </select>   
+      {{ range $i, $version := $Versions }}
+        {{ if eq $i 0 }}
+          <option value="">{{ $version }} Rocket (latest)</option>
+        {{ else }}
+          {{ $shortVer := split $version "." }}
+          {{ if ge (len $shortVer) 3 }}
+            <option value="{{$version}}">{{ index $shortVer 0 }}.{{ index $shortVer 1 }}.x</option>
+          {{ else }}
+            <option value="{{$version}}">{{ $version }}</option>
+          {{ end }}
+        {{ end }}
+      {{ end }}
+    </select>  
     {{ end }}
   </div>
 

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -15,11 +15,19 @@
           {{ if ge (len $shortVer) 3 }}
             <option value="{{$version}}">{{ index $shortVer 0 }}.{{ index $shortVer 1 }}.x</option>
           {{ else }}
-            <option value="{{$version}}">{{ $version }}</option>
+            {{ if eq $i 1 }}
+              <option value="{{$version}}">{{ $version }} T'Challa</option>
+            {{ else }}
+              {{ if eq $i 2 }}
+                <option value="{{$version}}">{{ $version }} Shuri</option>
+              {{ else }}
+                <option value="{{$version}}">{{ $version }} </option>
+              {{ end }}    
+            {{ end }}
           {{ end }}
         {{ end }}
       {{ end }}
-    </select>  
+    </select>
     {{ end }}
   </div>
 


### PR DESCRIPTION
Currently, Algolia search is picking up 20.11 search results before others. This was caused by a PR that simplified the version selector menu to incorporate feedback that release names should be next to release versions, and `master` should be at the end of the list of release versions. This caused issues with the `$version` variable (in /layouts/partials/footer.html line 18) that is used by Algolia for on-site search. 

This PR returns to the pre-existing version selector syntax that uses Hugo templating, except that we retain release names, and have "master" at the bottom of the list of releases.

Fixes DOC-327

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/hugo-docs/104)
<!-- Reviewable:end -->
