### PR TITLE
Rename master references.

### DIFF
--- a/layouts/_default/article.html
+++ b/layouts/_default/article.html
@@ -4,9 +4,9 @@
 {{ $latestVersion := index $versions 0 }}
 
 {{ if eq .Site.Params.site "dgraph-docs" }}
-  {{ if (eq $currentVersion "master") }}
+  {{ if (eq $currentVersion "main") }}
     <div class="alert alert-warning">
-      <i class="fa fa-warning"></i> You are looking at the docs for the unreleased <code>master</code> branch of Dgraph. The latest version is <a href="{{ .Site.BaseURL }}/..">{{ $latestVersion }}</a>.
+      <i class="fa fa-warning"></i> You are looking at the docs for the unreleased <code>main</code> branch of Dgraph. The latest version is <a href="{{ .Site.BaseURL }}/..">{{ $latestVersion }}</a>.
     </div>
   {{ else if not (eq $latestVersion $currentVersion) }}
     <div class="alert alert-warning">

--- a/layouts/_default/section.html
+++ b/layouts/_default/section.html
@@ -11,9 +11,9 @@
     {{/*  Ideally people never manually find these pages, but they could show up in search results  */}}
 
     {{ if eq .Site.Params.site "dgraph-docs" }}
-      {{ if (eq $currentVersion "master") }}
+      {{ if (eq $currentVersion "main") }}
         <div class="alert alert-warning">
-          <i class="fa fa-warning"></i> You are looking at the docs for the unreleased <code>master</code> branch of Dgraph. The
+          <i class="fa fa-warning"></i> You are looking at the docs for the unreleased <code>main</code> branch of Dgraph. The
           latest version is <a href="{{ .Site.BaseURL }}/..">{{ $latestVersion }}</a>.
         </div>
       {{ else if not (eq $latestVersion $currentVersion) }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -9,9 +9,9 @@
   <div class="content">
 
 {{ if eq .Site.Params.site "dgraph-docs" }}
-  {{ if (eq $currentVersion "master") }}
+  {{ if (eq $currentVersion "main") }}
     <div class="alert alert-warning">
-      <i class="fa fa-warning"></i> You are looking at the docs for the unreleased <code>master</code> branch of Dgraph. The latest version is <a href="{{ .Site.BaseURL }}/..">{{ $latestVersion }}</a>.
+      <i class="fa fa-warning"></i> You are looking at the docs for the unreleased <code>main</code> branch of Dgraph. The latest version is <a href="{{ .Site.BaseURL }}/..">{{ $latestVersion }}</a>.
     </div>
   {{ else if not (eq $latestVersion $currentVersion) }}
     <div class="alert alert-warning">

--- a/layouts/partials/example-curl.html
+++ b/layouts/partials/example-curl.html
@@ -7,7 +7,7 @@
 
 {{ $useOldHttpApi := or (lt $majorVersion 1) (and (eq $majorVersion 1) (le $minorVersion 0)) }}
 
-{{ if or (eq $currentBranch "master") (not $useOldHttpApi) }}
+{{ if or (eq $currentBranch "main") (not $useOldHttpApi) }}
     {{ if eq ( .Vars ) nil }}
         <pre><code class="no-copy" tabindex="-1">curl -H "Content-Type: application/dql" localhost:8080/query -XPOST -d '<br/><span class="query-content">{{ .Code }}</span>' | python -m json.tool | less
         </code></pre>

--- a/layouts/partials/example-go-grpc.html
+++ b/layouts/partials/example-go-grpc.html
@@ -3,14 +3,14 @@
 <!--
   Getting the version here is very hacky. It assumes that $current branch is either:
 
-  1. "master"
+  1. "main"
   2. "release/vX.Y.Z"
 -->
 {{ $version := split (slicestr (replace (printf "%-14s" $currentBranch) " " "0") 9) "." }}
 {{ $majorVersion := int (index $version 0) }}
 {{ $minorVersion := int (index $version 1) }}
 {{ $patchVersion := int (index $version 2) }}
-{{ $versionGe110 := or (eq $currentBranch "master") (gt $majorVersion 1) (and (eq $majorVersion 1) (gt $minorVersion 1)) (and (eq $majorVersion 1) (ge $minorVersion 1) (ge $patchVersion 0)) }}
+{{ $versionGe110 := or (eq $currentBranch "main") (gt $majorVersion 1) (and (eq $majorVersion 1) (gt $minorVersion 1)) (and (eq $majorVersion 1) (ge $minorVersion 1) (ge $patchVersion 0)) }}
 
 <pre><code class="no-copy" tabindex="-1">package main
 

--- a/layouts/partials/example-java.html
+++ b/layouts/partials/example-java.html
@@ -4,7 +4,7 @@
 {{ $majorVersion := int (index $version 0) }}
 {{ $minorVersion := int (index $version 1) }}
 {{ $patchVersion := int (index $version 2) }}
-{{ $versionGe105 := or (eq $currentBranch "master") (gt $majorVersion 1) (and (eq $majorVersion 1) (gt $minorVersion 0)) (and (eq $majorVersion 1) (eq $minorVersion 0) (ge $patchVersion 5)) }}
+{{ $versionGe105 := or (eq $currentBranch "main") (gt $majorVersion 1) (and (eq $majorVersion 1) (gt $minorVersion 0)) (and (eq $majorVersion 1) (eq $minorVersion 0) (ge $patchVersion 5)) }}
 
 <pre><code class="no-copy" tabindex="-1">{{ if .Vars }}import com.google.common.collect.ImmutableMap;
 {{ end }}import io.dgraph.DgraphClient;

--- a/layouts/partials/example-js-grpc.html
+++ b/layouts/partials/example-js-grpc.html
@@ -4,7 +4,7 @@
 {{ $majorVersion := int (index $version 0) }}
 {{ $minorVersion := int (index $version 1) }}
 {{ $patchVersion := int (index $version 2) }}
-{{ $versionGe105 := or (eq $currentBranch "master") (gt $majorVersion 1) (and (eq $majorVersion 1) (gt $minorVersion 0)) (and (eq $majorVersion 1) (eq $minorVersion 0) (ge $patchVersion 5)) }}
+{{ $versionGe105 := or (eq $currentBranch "main") (gt $majorVersion 1) (and (eq $majorVersion 1) (gt $minorVersion 0)) (and (eq $majorVersion 1) (eq $minorVersion 0) (ge $patchVersion 5)) }}
 
 <pre><code class="no-copy" tabindex="-1">const dgraph = require("dgraph-js");
 const grpc = require("grpc");

--- a/layouts/partials/example-js-http.html
+++ b/layouts/partials/example-js-http.html
@@ -4,7 +4,7 @@
 {{ $majorVersion := int (index $version 0) }}
 {{ $minorVersion := int (index $version 1) }}
 {{ $patchVersion := int (index $version 2) }}
-{{ $versionGe105 := or (eq $currentBranch "master") (gt $majorVersion 1) (and (eq $majorVersion 1) (gt $minorVersion 0)) (and (eq $majorVersion 1) (eq $minorVersion 0) (ge $patchVersion 5)) }}
+{{ $versionGe105 := or (eq $currentBranch "main") (gt $majorVersion 1) (and (eq $majorVersion 1) (gt $minorVersion 0)) (and (eq $majorVersion 1) (eq $minorVersion 0) (ge $patchVersion 5)) }}
 
 <pre><code class="no-copy" tabindex="-1">const dgraph = require("dgraph-js-http");
 

--- a/layouts/partials/example-python.html
+++ b/layouts/partials/example-python.html
@@ -4,7 +4,7 @@
 {{ $majorVersion := int (index $version 0) }}
 {{ $minorVersion := int (index $version 1) }}
 {{ $patchVersion := int (index $version 2) }}
-{{ $versionGe105 := or (eq $currentBranch "master") (gt $majorVersion 1) (and (eq $majorVersion 1) (gt $minorVersion 0)) (and (eq $majorVersion 1) (eq $minorVersion 0) (ge $patchVersion 5)) }}
+{{ $versionGe105 := or (eq $currentBranch "main") (gt $majorVersion 1) (and (eq $majorVersion 1) (gt $minorVersion 0)) (and (eq $majorVersion 1) (eq $minorVersion 0) (ge $patchVersion 5)) }}
 
 <pre><code class="no-copy" tabindex="-1">import pydgraph
 import json

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -6,7 +6,7 @@
       if (window.docsearch) {
         var version = 'latest';
         var path = window.location.pathname;
-        var arr = /(?:\/)?((?:master)|(?:v[0-9][^\/]+))(?:\/)?.*$/.exec(path);
+        var arr = /(?:\/)?((?:main)|(?:v[0-9][^\/]+))(?:\/)?.*$/.exec(path);
         if (arr != null && arr.length > 1) {
           version = arr[1];
         }

--- a/layouts/partials/suggest-edit.html
+++ b/layouts/partials/suggest-edit.html
@@ -1,4 +1,4 @@
 <a class="edit-btn" target="_blank"
-  href='https://github.com/dgraph-io/{{ .Site.Params.site }}/edit/{{ with getenv "CURRENT_BRANCH" }}{{ . }}{{ else }}master{{ end }}/content/{{with .File }}{{ replace ( replace .File.Path "\\" "/") "%5C" "/" }}{{ end }}'>
+  href='https://github.com/dgraph-io/{{ .Site.Params.site }}/edit/{{ with getenv "CURRENT_BRANCH" }}{{ . }}{{ else }}main{{ end }}/content/{{with .File }}{{ replace ( replace .File.Path "\\" "/") "%5C" "/" }}{{ end }}'>
   <i class="fa fa-github-alt"></i> Edit Page
 </a>

--- a/layouts/shortcodes/version.html
+++ b/layouts/shortcodes/version.html
@@ -2,7 +2,7 @@
   {{- with getenv "CURRENT_LATEST_TAG" -}}
     {{- . -}}
   {{- else -}}
-    master
+    main
   {{- end -}}
 {{- else -}}
   {{- getenv "CURRENT_VERSION" -}}

--- a/scripts/local.sh
+++ b/scripts/local.sh
@@ -40,10 +40,10 @@ LATEST_RELEASE=$(curl -s https://get.dgraph.io/latest \
   | head -1)
 
 
-export CURRENT_BRANCH="master"
-export CURRENT_VERSION="master"
+export CURRENT_BRANCH="main"
+export CURRENT_VERSION="main"
 export CURRENT_LATEST_TAG=LATEST_RELEASE
-export VERSIONS="master,$LATEST_RELEASE"
+export VERSIONS="main,$LATEST_RELEASE"
 export DGRAPH_ENDPOINT=${DGRAPH_ENDPOINT:-"https://play.dgraph.io/query?latency=true"}
 export CANONICAL_PATH="$HOST"
 
@@ -56,11 +56,11 @@ else
   BASE_URL=http://127.0.0.1:5500/public/
 fi
 
-build() # $1 = "master" | /v.+/ | "cloud"
+build() # $1 = "main" | /v.+/ | "cloud"
 {
-  if [[ $1 == "master" ]]; then
-    CURRENT_VERSION="master"
-    BRANCH="master"
+  if [[ $1 == "main" ]]; then
+    CURRENT_VERSION="main"
+    BRANCH="main"
     DIR=""
   elif [[ $1 == "cloud" ]]; then
     CURRENT_VERSION=
@@ -74,7 +74,7 @@ build() # $1 = "master" | /v.+/ | "cloud"
 
   HUGO_TITLE="Dgraph Theme Preview" \
     CANONICAL_PATH=${HOST} \
-    VERSIONS="master,$LATEST_RELEASE" \
+    VERSIONS="main,$LATEST_RELEASE" \
 		CURRENT_BRANCH=$BRANCH \
 		CURRENT_LATEST_TAG=$LATEST_RELEASE \
 		CURRENT_VERSION=$CURRENT_VERSION \
@@ -83,7 +83,7 @@ build() # $1 = "master" | /v.+/ | "cloud"
 		  --baseURL="$BASE_URL/$DIR" 1> /dev/null
 }
 
-build "master"
+build "main"
 
 git checkout "release/$LATEST_RELEASE" > /dev/null
 

--- a/static/js/dgraph.js
+++ b/static/js/dgraph.js
@@ -51,7 +51,7 @@ function eraseCookie(name) {
  * getCurrentVersion gets the current doc version from the URL path and returns it
  *
  * @params pathname {String} - current path in a format of '/current/path'.
- * @return {String} - e.g. 'master', 'v7.7.1', ''
+ * @return {String} - e.g. 'main', 'v7.7.1', ''
  *                    empty string denotes the latest version
  */
 function getCurrentVersion(pathname) {
@@ -63,7 +63,7 @@ function getCurrentVersion(pathname) {
     candidate = pathname.split("/")[1];
   }
 
-  if (candidate === "master") {
+  if (candidate === "main") {
     return candidate;
   }
 
@@ -379,7 +379,7 @@ function getPathAfterVersionName(location, versionName) {
   const versionSelectors = document.getElementsByClassName("version-selector");
   if (versionSelectors.length) {
     versionSelectors[0].addEventListener("change", function (e) {
-      // targetVersion: '', 'master', 'v0.7.7', 'v0.7.6', etc.
+      // targetVersion: '', 'main', 'v0.7.7', 'v0.7.6', etc.
       var targetVersion = e.target.value;
 
       if (currentVersion !== targetVersion) {


### PR DESCRIPTION
This will help the main docs script behave better. As we switched from master to main in Docs, this theme got a little out of sync. Because it assumes that we use Master instead of Main.